### PR TITLE
Fix manual adjusting time

### DIFF
--- a/src/pages/ManuallyAdjustTimePage.tsx
+++ b/src/pages/ManuallyAdjustTimePage.tsx
@@ -137,7 +137,6 @@ export const ManuallyAdjustTimePage: VFC = () => {
                                 </div>
                                 <TextField
                                     mustBeNumeric
-                                    value={row.desiredHours?.toFixed(2)?.toString()}
                                     onChange={(e) =>
                                         onDesiredHoursChange(idx, e.target.value)
                                     }


### PR DESCRIPTION
Using the manual adjust time function was broken, you could only input the numbers 6-9 and that would just increment the desired time by 0.01.

`Number.parseFloat()` in `onDesiredHoursChange()` automatically removed any trailing `.` in the input, which was then put back into the textinput value. This meant that the value wouldn't change.

Not having a default value in the textinput works around this.