### PR TITLE
Fixed playtime not updating after quitting the game

### DIFF
--- a/src/steam-ui/SteamPatches.ts
+++ b/src/steam-ui/SteamPatches.ts
@@ -35,7 +35,7 @@ class SteamPatches implements Mountable {
                         changedApps.push(appOverview)
                     }
                 }
-                appInfoStore.OnAppOverviewChange(changedApps)
+                //appInfoStore.OnAppOverviewChange(changedApps) // incompatible call + not needed
                 appStore.m_mapApps.set(
                     changedApps.map((app) => app.appid),
                     changedApps


### PR DESCRIPTION
OnAppOverviewChange expects a different kind of list and the commented call will fail with error in console.
It doesn't need to be called either as the handler creates AppInfo objects excluding non-Steam games.
The overridden m_mapApps setter will handle everything for us.

This fixes appid() is not a function error in console after quitting a game (when playtime is supposed to be updated) + now the window is instantly updated with new (changed) playtime, as it should be.
