### PR TITLE
Reversed MountManager unmount order

### DIFF
--- a/src/app/system.ts
+++ b/src/app/system.ts
@@ -54,7 +54,7 @@ class MountManager {
     }
 
     unMount() {
-        this.mounts.forEach((mount) => mount.unMount())
+        this.mounts.slice().reverse().forEach((mount) => mount.unMount())
         this.eventBus.emit({
             type: 'Unmount',
             createdAt: this.clock.getTimeMs(),


### PR DESCRIPTION
While debugging a weird issue I've noticed that mounting and unmounting mountables is following the same order.
Thinking this might cause some weird issues I've reversed the order of unmounting.

That said, it did nothing for the issue I've been hunting but also I haven't experienced any downsides. While it is generally a good idea to unmount in reverse order to mounting, if you think this is not needed I'll close the PR.